### PR TITLE
TRAD-259 Organization

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -907,7 +907,7 @@ message PoolReserves {
   string token1Address = 2;
   string token2Reserves = 3;
   string token2Address = 4;
-  string poolID = 5;
+  string poolAddress = 5;
   Project project = 6;
 }
 

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -15,7 +15,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     description: "Easy-to-use API for interacting with trader services on the Solana blockchain, powered by bloXroute Labs.";
     contact: {
       name: "bloXroute Labs";
-      url: "https://github.com/bloXroute-Labs/solana-trader-client-go";
+      url: "https://bloxroute.com/";
       email: "support@bloxroute.com";
     };
   };
@@ -24,6 +24,13 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 };
 
 service Api {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {
+    external_docs: {
+      description: "Detailed API documentation";
+      url: "https://bloxroute.gitbook.io/serum-api/about/welcome"
+    }
+  };
+
   rpc GetPrice(GetPriceRequest) returns (GetPriceResponse) {
     option (google.api.http) = {
       get: "/api/v1/market/price"

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -8,9 +8,24 @@ import "google/api/field_behavior.proto";
 import "google/api/visibility.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Trader API";
+    version: "1.1";
+    description: "Easy-to-use API for interacting with trader services on the Solana blockchain, powered by bloXroute Labs.";
+    contact: {
+      name: "bloXroute Labs";
+      url: "https://github.com/bloXroute-Labs/solana-trader-client-go";
+      email: "support@bloxroute.com";
+    };
+  };
+  consumes: "application/json";
+  produces: "application/json";
+};
+
 service Api {
   rpc GetPrice(GetPriceRequest) returns (GetPriceResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/price"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -21,7 +36,7 @@ service Api {
   }
 
   rpc GetMarkets(GetMarketsRequest) returns (GetMarketsResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/markets"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -32,7 +47,7 @@ service Api {
   }
 
   rpc GetPools(GetPoolsRequest) returns (GetPoolsResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/pools"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -43,7 +58,7 @@ service Api {
   }
 
   rpc GetTickers(GetTickersRequest) returns (GetTickersResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/tickers/{market}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -55,7 +70,7 @@ service Api {
 
   rpc GetKline(GetKlineRequest) returns (GetKlineResponse) {
     option (google.api.method_visibility).restriction = "INTERNAL";
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/kline/{market}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -89,7 +104,7 @@ service Api {
   }
 
   rpc GetQuotes(GetQuotesRequest) returns (GetQuotesResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       get: "/api/v1/market/quote"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -232,7 +247,7 @@ service Api {
   }
 
   rpc PostTradeSwap(TradeSwapRequest) returns (TradeSwapResponse) {
-    option(google.api.http) = {
+    option (google.api.http) = {
       post: "/api/v1/trade/swap"
       body: "*"
     };

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -348,13 +348,13 @@ service Api {
     };
   }
 
-  rpc GetQuotesStream(GetQuotesStreamRequest) returns (stream GetQuotesStreamResponse){
+  rpc GetQuotesStream(GetQuotesStreamRequest) returns (stream GetQuotesStreamResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "AMMs";
     };
   }
 
-  rpc GetPoolReservesStream(GetPoolReservesStreamRequest) returns (stream GetPoolReservesStreamResponse){
+  rpc GetPoolReservesStream(GetPoolReservesStreamRequest) returns (stream GetPoolReservesStreamResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "AMMs";
     };

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -38,7 +38,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of prices for specified tokens";
       summary: "Token prices";
-      tags: "Market/Universal";
+      tags: ["Market", "Universal"];
     };
   }
 
@@ -49,7 +49,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of orderbook markets";
       summary: "Orderbook markets";
-      tags: "Market/Orderbook";
+      tags: ["Market", "Orderbook"];
     };
   }
 
@@ -60,7 +60,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of supported AMM pools";
       summary: "AMM Pools";
-      tags: "Market/AMM";
+      tags: ["Market", "AMM"];
     };
   }
 
@@ -71,7 +71,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns updated ticker(s). To receive all tickers use empty string for {market} param value";
       summary: "Orderbook tickers";
-      tags: "Market/Orderbook";
+      tags: ["Market", "Orderbook"];
     };
   }
 
@@ -83,7 +83,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the KLine per market";
       summary: "Market KLine";
-      tags: "Market/Orderbook";
+      tags: ["Market", "Orderbook"];
     };
   }
 
@@ -94,7 +94,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns market's orderbook. Use limit param to reduce the number of bids/asks returned";
       summary: "Market orderbook";
-      tags: "Market/Orderbook";
+      tags: ["Market", "Orderbook"];
     };
   }
 
@@ -106,7 +106,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns recent trades on the market";
       summary: "Market trades";
-      tags: "Market/Orderbook";
+      tags: ["Market", "Orderbook"];
     };
   }
 
@@ -117,7 +117,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns quotes from supported AMMs";
       summary: "AMM Quotes";
-      tags: "Market/AMM";
+      tags: ["Market", "AMM"];
     };
   }
 
@@ -165,7 +165,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a NewOrderV3 unsigned transaction object";
       summary: "Unsigned NewOrderV3 transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -177,7 +177,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Submits a signed transaction";
       summary: "Transaction submit";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Universal"];
     };
   }
 
@@ -189,7 +189,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelOrder unsigned transaction object";
       summary: "Unsigned CancelOrder transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -201,7 +201,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelOrderByID unsigned transaction object";
       summary: "Unsigned CancelOrderByID transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -213,7 +213,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelAll unsigned transaction object";
       summary: "Unsigned CancelAll transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -225,7 +225,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a ReplaceByClientOrderID unsigned transaction object";
       summary: "Unsigned ReplaceByClientOrderID transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -237,7 +237,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a ReplaceOrder unsigned transaction object";
       summary: "Unsigned ReplaceOrder transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -249,7 +249,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a SettleFunds unsigned transaction object";
       summary: "Unsigned SettleFunds transaction";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -261,7 +261,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates an unsigned transaction object for the best available AMM swap";
       summary: "Unsigned best available AMM swap transaction";
-      tags: "Trade/AMM";
+      tags: ["Trade", "AMM"];
     };
   }
 
@@ -273,7 +273,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns all user's orders";
       summary: "List of user's orders";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -284,7 +284,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of open orders per user per market";
       summary: "List of user's open orders";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -296,7 +296,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns an order by ID";
       summary: "Order by ID";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 
@@ -307,7 +307,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the unsettled amounts of user in a market";
       summary: "Unsettled amounts";
-      tags: "Trade/Orderbook";
+      tags: ["Trade", "Orderbook"];
     };
   }
 

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -9,14 +9,25 @@ import "google/api/visibility.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 service Api {
+  rpc GetPrice(GetPriceRequest) returns (GetPriceResponse) {
+    option(google.api.http) = {
+      get: "/api/v1/market/price"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Returns the list of prices for specified tokens";
+      summary: "Token prices";
+      tags: "Market/Universal";
+    };
+  }
+
   rpc GetMarkets(GetMarketsRequest) returns (GetMarketsResponse) {
     option(google.api.http) = {
       get: "/api/v1/market/markets"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "Returns the list of supported markets";
-      summary: "Supported markets";
-      tags: "Market";
+      description: "Returns the list of orderbook markets";
+      summary: "Orderbook markets";
+      tags: "Market/Orderbook";
     };
   }
 
@@ -26,8 +37,8 @@ service Api {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of supported AMM pools";
-      summary: "Supported pools";
-      tags: "Market";
+      summary: "AMM Pools";
+      tags: "Market/AMM";
     };
   }
 
@@ -37,8 +48,8 @@ service Api {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns updated ticker(s). To receive all tickers use empty string for {market} param value";
-      summary: "List of tickers";
-      tags: "Market";
+      summary: "Orderbook tickers";
+      tags: "Market/Orderbook";
     };
   }
 
@@ -50,7 +61,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the KLine per market";
       summary: "Market KLine";
-      tags: "Market";
+      tags: "Market/Orderbook";
     };
   }
 
@@ -61,22 +72,34 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns market's orderbook. Use limit param to reduce the number of bids/asks returned";
       summary: "Market orderbook";
-      tags: "Market";
+      tags: "Market/Orderbook";
     };
   }
 
   rpc GetTrades(GetTradesRequest) returns (GetTradesResponse) {
+    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       get: "/api/v1/market/trades/{market}"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns recent trades on the market";
       summary: "Market trades";
-      tags: "Market";
+      tags: "Market/Orderbook";
     };
   }
 
+  rpc GetQuotes(GetQuotesRequest) returns (GetQuotesResponse) {
+    option(google.api.http) = {
+      get: "/api/v1/market/quote"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Returns quotes from supported AMMs";
+      summary: "AMM Quotes";
+      tags: "Market/AMM";
+    };
+  }
 
+  // system API
   rpc GetServerTime(GetServerTimeRequest) returns (GetServerTimeResponse) {
     option (google.api.http) = {
       get: "/api/v1/system/time"
@@ -120,7 +143,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a NewOrderV3 unsigned transaction object";
       summary: "Unsigned NewOrderV3 transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -132,7 +155,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Submits a signed transaction";
       summary: "Transaction submit";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -144,7 +167,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelOrder unsigned transaction object";
       summary: "Unsigned CancelOrder transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -156,7 +179,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelOrderByID unsigned transaction object";
       summary: "Unsigned CancelOrderByID transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -168,7 +191,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a CancelAll unsigned transaction object";
       summary: "Unsigned CancelAll transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -180,7 +203,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a ReplaceByClientOrderID unsigned transaction object";
       summary: "Unsigned ReplaceByClientOrderID transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -192,7 +215,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a ReplaceOrder unsigned transaction object";
       summary: "Unsigned ReplaceOrder transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -204,7 +227,19 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Generates a SettleFunds unsigned transaction object";
       summary: "Unsigned SettleFunds transaction";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
+    };
+  }
+
+  rpc PostTradeSwap(TradeSwapRequest) returns (TradeSwapResponse) {
+    option(google.api.http) = {
+      post: "/api/v1/trade/swap"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Generates an unsigned transaction object for the best available AMM swap";
+      summary: "Unsigned best available AMM swap transaction";
+      tags: "Trade/AMM";
     };
   }
 
@@ -216,7 +251,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns all user's orders";
       summary: "List of user's orders";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -227,7 +262,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the list of open orders per user per market";
       summary: "List of user's open orders";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -239,7 +274,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns an order by ID";
       summary: "Order by ID";
-      tags: "Trade";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -250,42 +285,7 @@ service Api {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Returns the unsettled amounts of user in a market";
       summary: "Unsettled amounts";
-      tags: "Trade";
-    };
-  }
-
-  // AMMs
-  rpc GetQuotes(GetQuotesRequest) returns (GetQuotesResponse) {
-    option(google.api.http) = {
-      get: "/api/v1/amm/quote"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "Returns the list quotes from supported amms";
-      summary: "Quotes list";
-      tags: "AMMs";
-    };
-  }
-
-  rpc GetPrice(GetPriceRequest) returns (GetPriceResponse) {
-    option(google.api.http) = {
-      get: "/api/v1/market/price"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "Returns the list of prices for supported tokens";
-      summary: "Prices list";
-      tags: "AMMs";
-    };
-  }
-
-  rpc PostTradeSwap(TradeSwapRequest) returns (TradeSwapResponse) {
-    option(google.api.http) = {
-      post: "/api/v1/amm/trade-swap"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "routes swaps from supported amms";
-      summary: "Routes swaps";
-      tags: "AMMs";
+      tags: "Trade/Orderbook";
     };
   }
 
@@ -734,7 +734,7 @@ message ProjectQuote {
   repeated QuoteRoute routes = 2;
 }
 
-message TradeSwapRequest{
+message TradeSwapRequest {
   Project project = 1;
   string ownerAddress = 2;
   string inToken = 3;
@@ -743,7 +743,7 @@ message TradeSwapRequest{
   double slippage = 6;
 }
 
-message TradeSwapResponse{
+message TradeSwapResponse {
   Project project = 1;
   repeated string transactions = 2;
   double outAmount = 3;


### PR DESCRIPTION
reorganizes endpoint after discussion with Daniel. Highlights:
 - get rid of `/amm` section
 - instead, move everything into either `/market` or `/trade`
 - add some general sectioning in swagger to indicate AMMs vs Orderbooks