### PR TITLE
Support new pump AMM pool endpoint in Rust and Python SDKs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-trader-proto"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["support@bloxroute.com"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bxsolana-trader-proto"
-version = "0.0.99"
+version = "0.1.0"
 
 description = "proto-generated files for solana-trader-api"
 dependencies = [


### PR DESCRIPTION
## Add support for new pump fun amm pool endpoint in Rust and Python SDKs.

- New libraries have already been published to crates.io and pypi, this simply increments the version for continuous development.

Rust: `v0.2.1` [link](https://crates.io/crates/solana-trader-proto/0.2.1)
Python: `v0.1.0` [link](https://pypi.org/project/bxsolana-trader-proto/0.1.0/)